### PR TITLE
fix: grpc-gateway plugin path

### DIFF
--- a/protobuf/buf.gen.go-server.yaml
+++ b/protobuf/buf.gen.go-server.yaml
@@ -3,16 +3,16 @@ managed:
   enabled: true
 plugins:
   - plugin: buf.build/protocolbuffers/go
-    out: ../proto/go-server
+    out: ./proto/go-server
     opt:
       - paths=source_relative
   - plugin: buf.build/grpc/go:v1.3.0
-    out: ../proto/go-server
+    out: ./proto/go-server
     opt:
       - require_unimplemented_servers=false
       - paths=source_relative
-  - plugin: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.10.3-1
-    out: ../proto/go-server
+  - plugin: buf.build/grpc-ecosystem/gateway:v2.18.1
+    out: ./proto/go-server
     opt:
       - paths=source_relative
       - generate_unbound_methods=true


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description

This PR fixes the the grpc-gateway plugin path.

Updates:

Fixed grpc-gateway plugin path in protobuf/buf.gen.go-server.yaml

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
