### PR TITLE
feat: Added kubeconfig in the request to support running Analyzer in remote cluster

### DIFF
--- a/protobuf/schema/v1/server_analyzer_service.proto
+++ b/protobuf/schema/v1/server_analyzer_service.proto
@@ -18,6 +18,7 @@ message AnalyzeRequest {
   string output = 8;
   repeated string filters = 9;
   string label_selector = 10;
+  string kubeconfig = 11;
 }
 
 message SensitiveData {


### PR DESCRIPTION
Added kubeconfig to the AnalyzeRequest to support API case

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes https://github.com/k8sgpt-ai/k8sgpt/issues/1271

## 📑 Description
We are running a central platform to manage cluster fleets and we would like to run k8sgpt from central cluster instead of running operator in all the clusters. therefore, we need to pass in kubeconfig when we call Analyze from central cluster to managed cluster

Added kubeconfig in Analyzer request to be consumed by the backend API logic

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
